### PR TITLE
Fix ghosts display and links

### DIFF
--- a/_includes/ghostLayout.njk
+++ b/_includes/ghostLayout.njk
@@ -1,5 +1,5 @@
 ---
-layout: ghostsLayout
+layout: baseLayout
 title: Ghost
 ---
 {{ content | safe }}

--- a/_includes/ghostsLayout.njk
+++ b/_includes/ghostsLayout.njk
@@ -5,7 +5,7 @@ layout: baseLayout
 <nav>
     <ul>
         {%- for ghost in ghosts %}
-            <li><a href="{{ ghost.name }}.html" class="ghost-name">{{ ghost.name }}</a></li>
+            <li><a href="{{ ghost.name | slugify }}.html" class="ghost-name">{{ ghost.name }}</a></li>
         {% endfor -%}
     </ul>
 </nav>

--- a/src/ghosts/ghost.njk
+++ b/src/ghosts/ghost.njk
@@ -9,7 +9,7 @@ permalink: "ghosts/{{ ghost.name | slugify }}.html"
 
 title: Ghost
 ---
-<h3 class="ghost-name">{{ ghost.name }}</h3>
+<h3 class="ghost-name">Ghost: {{ ghost.name }}</h3>
 {% if ghost.huntSanityThreshold.values %}
 <ul>
 Hunts at sanity threshold:


### PR DESCRIPTION
- Using the `slugify` filter fixes The Mimic and The Twins links.
- Changed ghost template to not display entire list of ghosts, since the list takes up too much space