### PR TITLE
Remove Netlify visual-diff plugin

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,16 +1,1 @@
-[[plugins]]
-    package = "netlify-plugin-visual-diff"
-    [plugins.inputs]
 
-        [[plugins.inputs.browser]]
-        name = "chrome"
-        width = 1024
-        height = 768
-
-        [[plugins.inputs.browser]]
-        name = "firefox"
-        width = 1024
-        height = 768
-
-        [[plugins.inputs.browser]]
-        deviceName = "iPhone 11 Pro"


### PR DESCRIPTION
Because I ran out of Applitools checkpoint for the month, and now apparently production builds are failing because of that.